### PR TITLE
chain: Fix memory leak

### DIFF
--- a/chain/Cargo.lock
+++ b/chain/Cargo.lock
@@ -7216,11 +7216,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]


### PR DESCRIPTION
I confirmed unusual memory usages, this fixes it.
```
cargo update -p thread_local
```

See https://github.com/paritytech/substrate/issues/8117