### PR TITLE
front: Fix upgrade coin bugs

### DIFF
--- a/front/src/components/common/Mtc/Shop/Nav.tsx
+++ b/front/src/components/common/Mtc/Shop/Nav.tsx
@@ -75,7 +75,7 @@ export function Nav(props: {
               props.disabled || props.upgradeCoin === null || props.upgradeCoin > props.coin
             }
           >
-            Upgrade {props.upgradeCoin ? getCoinText(props.upgradeCoin) : ""}
+            Upgrade {props.upgradeCoin === null ? "" : getCoinText(props.upgradeCoin)}
           </button>
           {props.finishFn.kind === "pow" ? (
             <PowButtonWrapper onClick={props.finishFn.fn} disabled={props.disabled} />

--- a/front/src/components/common/Mtc/Shop/index.tsx
+++ b/front/src/components/common/Mtc/Shop/index.tsx
@@ -138,7 +138,7 @@ export function Shop(props: {
           grade={props.mtcState.grade}
           upgradeFn={() => {
             const upgradeCoin = props.mtcState.upgradeCoin
-            if (!upgradeCoin) {
+            if (upgradeCoin === null) {
               throw new Error("invalid state: upgradeCoin null")
             }
             setShopState((s) => ({

--- a/front/src/misc/mtcUtils.ts
+++ b/front/src/misc/mtcUtils.ts
@@ -184,7 +184,7 @@ export const finishBattle = (
     mtcState.seed
   )
 
-  const upgradeCoin = mtcState.upgradeCoin ? Math.max(mtcState.upgradeCoin - 1, 0) : null
+  const upgradeCoin = mtcState.upgradeCoin === null ? null : Math.max(mtcState.upgradeCoin - 1, 0)
 
   return {
     mtcState: { ...mtcState, ...state, turn: mtcState.turn + 1, upgradeCoin, battleGhostIndex },


### PR DESCRIPTION
We had two bugs at shop.

- When the upgrade cost is zero, clicking the upgrade button, we get an error.
- When the upgrade cost is zero, proceeding the next turn, the upgrade button is disabled.

0 is falsy in JavaScript.