### PR TITLE
front: Fix warning, do not touch states of unmounted components

### DIFF
--- a/front/src/components/pages/Top/DemoMtcBattle.tsx
+++ b/front/src/components/pages/Top/DemoMtcBattle.tsx
@@ -23,6 +23,8 @@ function Inner(props: { bases: EmoBases }) {
   const [ghostBoard, setGhostBoard] = React.useState<mtc_GhostBoard | null>(null)
 
   React.useEffect(() => {
+    let isMounted = true
+
     query((q) => q.game.deckFixedEmoBaseIds()).then((idsOpt) => {
       if (idsOpt.isNone) {
         return
@@ -62,10 +64,16 @@ function Inner(props: { bases: EmoBases }) {
         }
       }
 
-      setSeed(`${Math.round(Math.random() * 10000)}`)
-      setBoard(createType("mtc_Board", _board))
-      setGhostBoard(createType("mtc_GhostBoard", _ghostBoard))
+      if (isMounted) {
+        setSeed(`${Math.round(Math.random() * 10000)}`)
+        setBoard(createType("mtc_Board", _board))
+        setGhostBoard(createType("mtc_GhostBoard", _ghostBoard))
+      }
     })
+
+    return () => {
+      isMounted = false
+    }
   }, [])
 
   if (seed === null || board === null || ghostBoard === null) {


### PR DESCRIPTION
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
    at Inner (http://localhost:8080/index.js:49145:62)
    at DemoMtcBattle (http://localhost:8080/index.js:49127:58)
```