### PR TITLE
chain: Prefer wasm execution for runtime

### DIFF
--- a/chain/Makefile
+++ b/chain/Makefile
@@ -20,12 +20,12 @@ rbuild:
 
 .PHONY: dev
 dev:
-	./target/release/open-emoji-battler --dev --base-path=./data
+	./target/release/open-emoji-battler --dev --base-path=./data --execution wasm
 
 # require native runtime
 .PHONY: dev-with-log
 dev-with-log:
-	RUST_BACKTRACE=1 ./target/release/open-emoji-battler -lpallet_transaction_payment_pow=debug -lpallet_game=debug --dev --base-path=./data
+	RUST_BACKTRACE=1 ./target/release/open-emoji-battler -lpallet_transaction_payment_pow=debug -lpallet_game=debug --dev --base-path=./data --execution wasm
 
 .PHONY: purge-dev
 purge-dev:


### PR DESCRIPTION
Always wasm makes the situation easier.
No benefits for using the native.