### PR TITLE
Call redeposit for NFT to free some KSM

### DIFF
--- a/oneshots/20230407_uniquesRedeposit.ts
+++ b/oneshots/20230407_uniquesRedeposit.ts
@@ -1,0 +1,23 @@
+import { connected, range } from "common"
+import { getKeyringPair } from "common/src/scriptUtils"
+
+const main = async () => {
+  const collectionId = 3
+  const itemIds = range(1306)
+
+  const sender = await getKeyringPair(process.argv[2])
+
+  // console.log(sender.address, itemIds)
+  // return
+
+  await connected(
+    "wss://statemine-rpc.polkadot.io",
+    async (api) => {
+      const txHash = await api.tx.uniques.redeposit(collectionId, itemIds).signAndSend(sender)
+      console.log(txHash.toString())
+    },
+    false
+  )
+}
+
+main()


### PR DESCRIPTION
In https://github.com/paritytech/cumulus/pull/1332, the deposits of `pallet-uniques` have been lowered.

Using this script, I got some locked KSM back. The result is here: https://statemine.subscan.io/extrinsic/4234273-2
